### PR TITLE
Reset rootElementClass for newsletter Text_Component

### DIFF
--- a/KwcNewsletter/Kwc/Newsletter/Detail/Mail/Paragraphs/TextImage/Text/Component.php
+++ b/KwcNewsletter/Kwc/Newsletter/Detail/Mail/Paragraphs/TextImage/Text/Component.php
@@ -1,12 +1,11 @@
 <?php
-class KwcNewsletter_Kwc_Newsletter_Detail_Mail_Paragraphs_TextImage_Text_Component
-    extends Kwc_Basic_Text_Component
+class KwcNewsletter_Kwc_Newsletter_Detail_Mail_Paragraphs_TextImage_Text_Component extends Kwc_Basic_Text_Component
 {
     public static function getSettings($param = null)
     {
         $ret = parent::getSettings($param);
-        $ret['generators']['child']['component']['link'] =
-            'KwcNewsletter_Kwc_Newsletter_Detail_Mail_Paragraphs_LinkTag_Component';
+        $ret['rootElementClass'] = '';
+        $ret['generators']['child']['component']['link'] = 'KwcNewsletter_Kwc_Newsletter_Detail_Mail_Paragraphs_LinkTag_Component';
         return $ret;
     }
 }


### PR DESCRIPTION
Styles set for the 'kwfUp-webStandard' class do not work in html-mails.
This class would previously cause the preview of a newsletter to be styled differently than the actual newsletter mail.