### PR TITLE
show shorttext when newsletter command is finished instead of text

### DIFF
--- a/Bundle/Command/Newsletter.php
+++ b/Bundle/Command/Newsletter.php
@@ -198,7 +198,7 @@ class Newsletter extends Command
             array(
                 "\n",
                 "$count Newsletters sent ($average/minute), $countErrors errors, $countNoUser user not found.",
-                $info['text']
+                $info['shortText']
             ),
             OutputInterface::VERBOSITY_VERBOSE
         );


### PR DESCRIPTION
text isnt always defined and more infos are also shown above