### PR TITLE
Add save, add and delete buttons for categories

### DIFF
--- a/KwcNewsletter/Kwc/Newsletter/CategoriesController.php
+++ b/KwcNewsletter/Kwc/Newsletter/CategoriesController.php
@@ -3,7 +3,7 @@ class KwcNewsletter_Kwc_Newsletter_CategoriesController extends Kwf_Controller_A
 {
     protected $_modelName = 'KwcNewsletter\Bundle\Model\Categories';
     protected $_position = 'pos';
-    protected $_buttons = array('csv');
+    protected $_buttons = array('save', 'add', 'delete', 'csv');
 
     protected function _initColumns()
     {


### PR DESCRIPTION
Previously the buttons were added by the parent.
They were accidentally removed when the "csv" button was added in 3712daf.