### PR TITLE
Directly return status

### DIFF
--- a/Bundle/Model/Row/Newsletters.php
+++ b/Bundle/Model/Row/Newsletters.php
@@ -37,24 +37,9 @@ class Newsletters extends \Kwf_Model_Proxy_Row
         throw new \Kwf_Exception("moved to cli controller");
     }
 
-    protected function _afterSave()
-    {
-        parent::_afterSave();
-
-        if ($this->getStatus() !== $this->status) {
-            \Kwf_Cache_Simple::delete("kwcNewsletterStatus-{$this->id}");
-        }
-    }
-
     public function getStatus()
     {
-        $cacheId = "kwcNewsletterStatus-{$this->id}";
-        $status = \Kwf_Cache_Simple::fetch($cacheId, $success);
-        if (!$success) {
-            $status = $this->getModel()->fetchColumnByPrimaryId('status', $this->id);
-            \Kwf_Cache_Simple::add($cacheId, $status);
-        }
-        return $status;
+        return $this->getModel()->fetchColumnByPrimaryId('status', $this->id);
     }
 
     public function getNextQueueRows($sendProcessPid)


### PR DESCRIPTION
Storing the status in memcache could sometimes cause problems when sending the newsletters.