### PR TITLE
Make Koala 5.2 compatible

### DIFF
--- a/KwcNewsletter/Kwc/Newsletter/Detail/PreviewPanel.js
+++ b/KwcNewsletter/Kwc/Newsletter/Detail/PreviewPanel.js
@@ -12,7 +12,7 @@ Kwc.Newsletter.Detail.PreviewPanel = Ext2.extend(Kwf.Binding.AbstractPanel, {
     initComponent : function()
     {
         this.button['html'] = new Ext2.Toolbar.Button ({
-            icon    : KWF_BASE_URL+'/assets/silkicons/html.png',
+            icon    : '/assets/silkicons/html.png',
             cls     : 'x2-btn-text-icon',
             text    : trlKwf('HTML'),
             enableToggle: true,
@@ -23,7 +23,7 @@ Kwc.Newsletter.Detail.PreviewPanel = Ext2.extend(Kwf.Binding.AbstractPanel, {
             name : 'html'
         });
         this.button['text'] = new Ext2.Toolbar.Button ({
-            icon    : KWF_BASE_URL+'/assets/silkicons/page_white_text.png',
+            icon    : '/assets/silkicons/page_white_text.png',
             cls     : 'x2-btn-text-icon',
             text    : trlKwf('Text'),
             enableToggle: true,
@@ -35,7 +35,7 @@ Kwc.Newsletter.Detail.PreviewPanel = Ext2.extend(Kwf.Binding.AbstractPanel, {
         });
 
         this.sendButton = new Ext2.Toolbar.Button ({
-            icon    : KWF_BASE_URL+'/assets/silkicons/email_go.png',
+            icon    : '/assets/silkicons/email_go.png',
             cls     : 'x2-btn-text-icon',
             text    : trlKwf('Send'),
             handler : function(a, b, c) {

--- a/KwcNewsletter/Kwc/Newsletter/Detail/RecipientsAction.js
+++ b/KwcNewsletter/Kwc/Newsletter/Detail/RecipientsAction.js
@@ -3,7 +3,7 @@ Ext2.ns('Kwc.Newsletter.Detail');
 Kwc.Newsletter.Detail.RecipientsAction = Ext2.extend(Ext2.Action, {
     constructor: function(config){
         config = Ext2.apply({
-        icon    : KWF_BASE_URL+'/assets/silkicons/database_add.png',
+        icon    : '/assets/silkicons/database_add.png',
         cls     : 'x2-btn-text-icon',
         text    : trlKwf('Add recipients to the queue'),
         tooltip : trlKwf('Adds the currently shown recipients to the newsletter'),
@@ -53,7 +53,7 @@ Kwc.Newsletter.Detail.RecipientsAction = Ext2.extend(Ext2.Action, {
 Kwc.Newsletter.Detail.RemoveRecipientsAction = Ext2.extend(Ext2.Action, {
     constructor: function(config){
         config = Ext2.apply({
-        icon    : KWF_BASE_URL+'/assets/silkicons/database_delete.png',
+        icon    : '/assets/silkicons/database_delete.png',
         cls     : 'x2-btn-text-icon',
         text    : trlKwf('Remove recipients from the queue'),
         tooltip : trlKwf('Removes the currently shown recipients from the newsletter'),

--- a/KwcNewsletter/Kwc/Newsletter/Detail/RecipientsQueuePanel.js
+++ b/KwcNewsletter/Kwc/Newsletter/Detail/RecipientsQueuePanel.js
@@ -4,7 +4,7 @@ Kwc.Newsletter.Detail.RecipientsQueuePanel = Ext2.extend(Kwf.Auto.GridPanel, {
     initComponent: function() {
         this.actions.deleteAll = new Ext2.Action({
             text: trlKwf('Delete All'),
-            icon: KWF_BASE_URL+'/assets/silkicons/bin_empty.png',
+            icon: '/assets/silkicons/bin_empty.png',
             cls: 'x2-btn-text-icon',
             handler: function(){
                 Ext2.Msg.confirm(

--- a/KwcNewsletter/Kwc/Newsletter/Detail/TabPanel.js
+++ b/KwcNewsletter/Kwc/Newsletter/Detail/TabPanel.js
@@ -6,7 +6,7 @@ Kwc.Newsletter.Detail.TabPanel = Ext2.extend(Kwf.Binding.TabPanel,
         this.border = false;
         this.backButton = new Ext2.Action({
             text: trlKwf('Back'),
-            icon: KWF_BASE_URL+'/assets/silkicons/arrow_left.png',
+            icon: '/assets/silkicons/arrow_left.png',
             cls: 'x2-btn-text-icon',
             handler: this.onBack,
             disabled: true,
@@ -14,7 +14,7 @@ Kwc.Newsletter.Detail.TabPanel = Ext2.extend(Kwf.Binding.TabPanel,
         });
         this.nextButton = new Ext2.Action({
             text: trlKwf('Next'),
-            icon: KWF_BASE_URL+'/assets/silkicons/arrow_right.png',
+            icon: '/assets/silkicons/arrow_right.png',
             cls: 'x2-btn-text-icon',
             handler: this.onNext,
             scope: this

--- a/KwcNewsletter/Kwc/Newsletter/Subscribe/RecipientsPanel.js
+++ b/KwcNewsletter/Kwc/Newsletter/Subscribe/RecipientsPanel.js
@@ -31,7 +31,7 @@ Kwc.Newsletter.Subscribe.RecipientsPanel = Ext2.extend(Kwf.Binding.ProxyPanel, {
 
         this._subscribersGrid.actions.unsubscribe = new Ext2.Action({
             text: trlKwf('Unsubscribe'),
-            icon: KWF_BASE_URL+'/assets/silkicons/table_delete.png',
+            icon: '/assets/silkicons/table_delete.png',
             cls: 'x2-btn-text-icon',
             needsSelection: true,
             handler : function() {


### PR DESCRIPTION
Avoid creating a kwc-newsletter 1.1 version by dropping KWF_BASE_URL-functionality also in Koala-5.1 (which is in fact never used).
After merging I will delete 1.1.