### PR TITLE
Remove CSS3 compass-mixins

### DIFF
--- a/KwcNewsletter/Kwc/Newsletter/Detail/StartNewsletterPanel.scss
+++ b/KwcNewsletter/Kwc/Newsletter/Detail/StartNewsletterPanel.scss
@@ -1,8 +1,4 @@
 @import "compass/utilities/general/clearfix";
-@import "compass/css3/images";
-@import "compass/css3/opacity";
-@import "kwf/css3/border-radius";
-@import "kwf/css3/box-shadow";
 
 .kwcNewsletterButtons {
     @include pie-clearfix;
@@ -13,7 +9,7 @@
         float: left;
 
         button {
-            @include border-radius-pie(3px);
+            border-radius: 3px;
             width: 90%;
             margin: 0px auto 0px auto;
             display: block;
@@ -29,7 +25,7 @@
 
             .kwcNewsletterButtonStart {
                 background-color: #7fbf4d;
-                @include background-image(linear-gradient(#7fbf4d, #63a62f));
+                background-image: linear-gradient(#7fbf4d, #63a62f);
                 text-shadow: 0 -1px 0 #4C9021;
                 border: 1px solid #63A62F;
                 border-bottom: 1px solid #5B992B;
@@ -37,17 +33,17 @@
 
                 &:hover {
                     background-color: #76b347;
-                    @include background-image(linear-gradient(#76b347, #5e9e2e));
+                    background-image: linear-gradient(#76b347, #5e9e2e);
                 }
 
                 &:active {
                     border: 1px solid #5B992B;
                     border-bottom: 1px solid #538C27;
-                    @include box-shadow-pie(#548c29 0px 0px 8px 4px inset);
+                    box-shadow: 0 0 8px 4px #548c29 inset;
                 }
 
                 &[disabled=disabled], &[disabled] {
-                    @include opacity(0.6);
+                    opacity: 0.6;
                     cursor: default;
                 }
             }
@@ -58,7 +54,7 @@
 
             .kwcNewsletterButtonPause {
                 background-color: #eee;
-                @include background-image(linear-gradient(#eee, #ccc));
+                background-image: linear-gradient(#eee, #ccc);
                 text-shadow: 0 1px 0 #eee;
                 border: 1px solid #ccc;
                 border-bottom: 1px solid #bbb;
@@ -66,7 +62,7 @@
 
                 &:hover {
                     background-color: #ddd;
-                    @include background-image(linear-gradient(#ddd, #bbb));
+                    background-image: linear-gradient(#ddd, #bbb);
                     border: 1px solid #bbb;
                     border-bottom: 1px solid #999;
                 }
@@ -74,7 +70,7 @@
                 &:active {
                     border: 1px solid #aaa;
                     border-bottom: 1px solid #888;
-                    @include box-shadow-pie(#aaa 0px 0px 8px 4px inset);
+                    box-shadow: 0 0 8px 4px #aaa inset;
                 }
             }
         }


### PR DESCRIPTION
They are no longer necessary because of the autoprefixer that was added in Koala-Framework 4.1.